### PR TITLE
fixed null exception

### DIFF
--- a/lib/models/video_page.dart
+++ b/lib/models/video_page.dart
@@ -44,7 +44,7 @@ class VideoPage {
         channelName: map?['results']['results']['contents'][1]['videoSecondaryInfoRenderer']['owner']['videoOwnerRenderer']['title']['runs'][0]['text'],
         viewCount: map?['results']['results']['contents'][0]['videoPrimaryInfoRenderer']['viewCount']['videoViewCountRenderer']['shortViewCount']['simpleText'],
         subscribeCount: map?['results']?['results']?['contents']?[1]?['videoSecondaryInfoRenderer']?['owner']?['videoOwnerRenderer']?['subscriberCountText']?['simpleText'],
-        likeCount: map?['results']['results']['contents'][0]['videoPrimaryInfoRenderer']['videoActions']['menuRenderer']['topLevelButtons'][0]['toggleButtonRenderer']['defaultText']['simpleText'],
+        likeCount: map?['results']['results']['contents'][0]['videoPrimaryInfoRenderer']['videoActions']['menuRenderer']['topLevelButtons'][0]['segmentedLikeDislikeButtonRenderer']['likeButton']['toggleButtonRenderer']['defaultText']['simpleText'],
         unlikeCount: '',
         description: collectDescriptionString(
             map?['results']?['results']?['contents']?[1]?['videoSecondaryInfoRenderer']?['description']?['runs']),


### PR DESCRIPTION
I kept getting this an exception when I call the function `youtubeDataApi.fetchVideoData(videoId)`. Below is the exception.

Unhandled Exception: NoSuchMethodError: The method '[]' was called on null.
E/flutter (16928): Receiver: null
E/flutter (16928): Tried calling: []("defaultText")
E/flutter (16928): #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
E/flutter (16928): #1      new VideoPage.fromMap (package:youtube_data_api/models/video_page.dart:47:167)
E/flutter (16928): #2      YoutubeDataApi.fetchVideoData (package:youtube_data_api/youtube_data_api.dart:435:28)
E/flutter (16928): <asynchronous suspension>
E/flutter (16928): #3      _FutureBuilderState._subscribe.<anonymous closure> (package:flutter/src/widgets/async.dart:628:33)

It seems youtube updated their apis, so I modified the code to fit with what the api was returning.